### PR TITLE
Python 3 compatibility and linting fixes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ contributions from:
 
 - Evgeniy Getmanskiy <getmansky@steelkiwi.com>
 - Diogo Vieira <dfv@eurotux.com>
+- Lucas Estienne <lucas.estienne@cira.ca>

--- a/eppy/__init__.py
+++ b/eppy/__init__.py
@@ -1,1 +1,6 @@
+"""
+eppy is a Python-based API for the Extensible Provisioning Protocol (EPP),
+commonly used for communication between domain registries and registrars.
+"""
+
 __version__ = "0.8"

--- a/eppy/childorder.py
+++ b/eppy/childorder.py
@@ -1,7 +1,20 @@
+"""
+Module containing the definition of the order that child elements should be serialized
+"""
 
-
-CMD_BASE = ('check', 'create', 'delete', 'info', 'login', 'logout', 'poll', 'renew', 'transfer', 'update',  # one of
-            'extension', 'clTRID')
+CMD_BASE = (
+    'check',
+    'create',
+    'delete',
+    'info',
+    'login',
+    'logout',
+    'poll',
+    'renew',
+    'transfer',
+    'update',
+    'extension',
+    'clTRID')
 
 CMD_LOGIN = ('clID',
              'pw',
@@ -9,10 +22,23 @@ CMD_LOGIN = ('clID',
              'options',
              'svcs')
 
-CMD_CREATE_DOMAIN = ('name', 'period', 'ns', 'registrant', 'contact', 'authInfo')
+CMD_CREATE_DOMAIN = (
+    'name',
+    'period',
+    'ns',
+    'registrant',
+    'contact',
+    'authInfo')
 CMD_RENEW_DOMAIN = ('name', 'curExpDate', 'period')
 
-CMD_CREATE_CONTACT = ('id', 'postalInfo', 'voice', 'fax', 'email', 'authInfo', 'disclose')
+CMD_CREATE_CONTACT = (
+    'id',
+    'postalInfo',
+    'voice',
+    'fax',
+    'email',
+    'authInfo',
+    'disclose')
 
 CMD_CREATE_HOST = ('name', 'addr')
 
@@ -22,7 +48,13 @@ CMD_INFO_CONTACT = ('id', 'authInfo')
 CMD_UPDATE_DOMAIN = ('name', 'add', 'rem', 'chg')
 
 CMD_UPDATE_CONTACT = ('id', 'add', 'rem', 'chg')
-CMD_UPDATE_CONTACT_CHG = ('postalInfo', 'voice', 'fax', 'email', 'authInfo', 'disclose')
+CMD_UPDATE_CONTACT_CHG = (
+    'postalInfo',
+    'voice',
+    'fax',
+    'email',
+    'authInfo',
+    'disclose')
 
 CMD_TRANSFER_DOMAON = ('name', 'period', 'authInfo')
 CMD_TRANSFER_CONTACT = ('id', 'period', 'authInfo')

--- a/eppy/constants.py
+++ b/eppy/constants.py
@@ -1,66 +1,70 @@
+""" EPP Result Codes """
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-""" EPP Result Codes """
 
-EPP_OK =                      r'1000'
+EPP_OK = r'1000'
 
-EPP_OK_PENDING =              r'1001'
+EPP_OK_PENDING = r'1001'
 
-EPP_QUEUE_EMPTY =             r'1300'
+EPP_QUEUE_EMPTY = r'1300'
 
-EPP_QUEUE_NOT_EMPTY =         r'1301'
+EPP_QUEUE_NOT_EMPTY = r'1301'
 
-EPP_LOGOUT_OK =               r'1500'
+EPP_LOGOUT_OK = r'1500'
 
 # command element that is not defined by EPP
-EPP_UNKNOWN_CMD =             r'2000'
+EPP_UNKNOWN_CMD = r'2000'
 
 # improperly formed command element
-EPP_CMD_SYNTAX =              r'2001'
+EPP_CMD_SYNTAX = r'2001'
 
 # properly formed command element but the command cannot be executed
 # due to a sequencing or context error, e.g. <logout> before <login>
-EPP_CMD_USE =                 r'2002'
+EPP_CMD_USE = r'2002'
 
 # command for which a required parameter value has not been provided
-EPP_PARAM_MISSING =           r'2003'
+EPP_PARAM_MISSING = r'2003'
 
 # command parameter whose value is outside the range of values specified by the protocol.
 # The error value SHOULD be returned via a <value> element in the EPP response
-EPP_PARAM_VALUE_RANGE =       r'2004'
+EPP_PARAM_VALUE_RANGE = r'2004'
 
 # command containing a parameter whose value is improperly formed.
 # The error value SHOULD be returned via a <value> element in the EPP response
-EPP_PARAM_VALUE_SYNTAX =      r'2005'
+EPP_PARAM_VALUE_SYNTAX = r'2005'
 
-# command element specifying a protocol version that is not implemented by the server.
+# command element specifying a protocol version that is not implemented by
+# the server.
 EPP_UNIMPLEMENTED_PROTO_VER = r'2100'
 
 # valid EPP command element that is not implemented by the server.
-EPP_UNIMPLEMENTED_COMMAND   = r'2101'
+EPP_UNIMPLEMENTED_COMMAND = r'2101'
 
-# valid EPP command element that contains a protocol option that is not implemented by the server
-EPP_UNIMPLEMENTED_OPTION   = r'2102'
+# valid EPP command element that contains a protocol option that is not
+# implemented by the server
+EPP_UNIMPLEMENTED_OPTION = r'2102'
 
-# valid EPP command element that contains a protocol command extension that is not implemented by the server
+# valid EPP command element that contains a protocol command extension
+# that is not implemented by the server
 EPP_UNIMPLEMENTED_EXTENSION = r'2103'
 
-# attemps to execute a billable operation and the command cannot be completed due to a client-billing failure.
-EPP_BILLING_FAIL =            r'2104'
+# attemps to execute a billable operation and the command cannot be
+# completed due to a client-billing failure.
+EPP_BILLING_FAIL = r'2104'
 
 # object that is not eligible for renewal in accordance with server policy
-EPP_INELIGIBLE_RENEW =        r'2105'
+EPP_INELIGIBLE_RENEW = r'2105'
 
 # object that is not eligible for transfer in accordance with server policy
-EPP_INELIGIBLE_TRANSFER =     r'2106'
+EPP_INELIGIBLE_TRANSFER = r'2106'
 
 # error when validating client credentials
-EPP_AUTHN_ERROR =             r'2200'
+EPP_AUTHN_ERROR = r'2200'
 
 # client-authorization error when executing a command. This error
 # is used to note that a client lacks privileges to execute the requested command
-EPP_AUTHORIZATION_ERROR =     r'2201'
+EPP_AUTHORIZATION_ERROR = r'2201'
 
 # invalid command authorization information when attempting
 # to confirm authorization to execute a command.  This error
@@ -68,61 +72,59 @@ EPP_AUTHORIZATION_ERROR =     r'2201'
 # to execute the requested command, but the authorization
 # information provided by the client does not match the
 # authorization information archived by the server
-EPP_INVALID_AUTH_INFO   =     r'2202'
+EPP_INVALID_AUTH_INFO = r'2202'
 
-# command to transfer an object that is pending transfer due to an earlier transfer request
-EPP_OBJECT_PENDING_XFR =      r'2300'
+# command to transfer an object that is pending transfer due to an earlier
+# transfer request
+EPP_OBJECT_PENDING_XFR = r'2300'
 
 # received command to confirm, reject, or cancel the transfer of an
 # object when no command has been made to transfer the object.
-EPP_OBJECT_NOT_PENDING_XFR =  r'2301'
+EPP_OBJECT_NOT_PENDING_XFR = r'2301'
 
 # command to create an object that already exists in the repository
-EPP_OBJECT_EXISTS =           r'2302'
+EPP_OBJECT_EXISTS = r'2302'
 
 # command to query or transform an object that does not exist in the repository
-EPP_OBJECT_DOES_NOT_EXIST =   r'2303'
+EPP_OBJECT_DOES_NOT_EXIST = r'2303'
 
 # command to transform an object that cannot be completed
 # due to server policy or business practices.
-EPP_OBJECT_STATUS =           r'2304'
+EPP_OBJECT_STATUS = r'2304'
 
 # command to transform an object that cannot be completed
 # due to dependencies on other objects that are associated
 # with the target object.
-EPP_OBJECT_ASSOC =            r'2305'
+EPP_OBJECT_ASSOC = r'2305'
 
 # command containing a parameter value that is syntactically valid
 # but semantically invalid due to local policy.
 # The error value SHOULD be returned via a <value> element in the EPP response.
-EPP_PARAM_VALUE_POLICY =      r'2306'
+EPP_PARAM_VALUE_POLICY = r'2306'
 
 # a command to operate on an object service that is not supported by the server
-EPP_UNIMPLEMENTED_OBJ_SVC =   r'2307'
+EPP_UNIMPLEMENTED_OBJ_SVC = r'2307'
 
 # command whose execution results in a violation of server data management policies
-EPP_DATA_MGMT_POLICY =        r'2308'
+EPP_DATA_MGMT_POLICY = r'2308'
 
 # unable to execute a command due to an internal server error
 # that is not related to the protocol. The failure can be transient.
-EPP_FAILED =                  r'2400'
+EPP_FAILED = r'2400'
 
 # command that cannot be completed due to an internal server error
 # that is not related to the protocol. The failure is not transient
 # and will cause other commands to fail as well.
 # The server MUST end the active session and close the existing connection.
-EPP_FAILED_CLOSING =          r'2500'
+EPP_FAILED_CLOSING = r'2500'
 
 # error when validating client credentials and
 # a server-defined limit on the number of allowable failures has been exceeded.
 # The server MUST close the existing connection.
-EPP_AUTH_FAILED_CLOSING =     r'2501'
+EPP_AUTH_FAILED_CLOSING = r'2501'
 
 # <login> command that cannot be completed because the client has exceeded
 # a system-defined limit on the number of sessions that the client can establish.
 # It might be possible to establish a session by ending existing unused sessions
 # and closing inactive connections.
-EPP_AUTH_SESSION_LIMIT =      r'2502'
-
-
-
+EPP_AUTH_SESSION_LIMIT = r'2502'

--- a/eppy/doc.py
+++ b/eppy/doc.py
@@ -1,11 +1,11 @@
 # pylint: disable=C0111
 
+import copy
 from eppy.xmldict import XmlDictObject
 from eppy.xmldict import _BASE_NSMAP
-import copy
 from past.builtins import unicode, basestring # Python 2 backwards compatibility
-from . import childorder
 from six import iteritems
+from . import childorder
 from .utils import gen_trid
 
 EPP_NSMAP = dict(_BASE_NSMAP)
@@ -62,7 +62,7 @@ class EppDoc(XmlDictObject):
     def __str__(self):
         return unicode(self).encode('utf-8')
 
-    # pylint: disable=w0212
+    # pylint: disable=w0212, e1101
     @classmethod
     def cmddef(cls):
         """
@@ -87,7 +87,7 @@ class EppDoc(XmlDictObject):
                 dpath_get(dct, aclass._path)['_nsmap'] = aclass._nsmap
         return dct
 
-    # pylint: disable=w0212
+    # pylint: disable=w0212, e1101
     @classmethod
     def annotate(cls, dct=None):
         """
@@ -119,19 +119,19 @@ class EppDoc(XmlDictObject):
         return self.__class__.annotate(self)
 
     @classmethod
-    def _annotate_order_recurse(cls, dct, childorder):
-        if childorder.get('__order'):
-            dct['_order'] = childorder['__order']
-        for k in (k for k in childorder.keys() if k != '__order'):
+    def _annotate_order_recurse(cls, dct, childorder_):
+        if childorder_.get('__order'):
+            dct['_order'] = childorder_['__order']
+        for k in (k for k in childorder_.keys() if k != '__order'):
             child = dct.get(k)
             if isinstance(child, dict):
-                cls._annotate_order_recurse(child, childorder[k])
+                cls._annotate_order_recurse(child, childorder_[k])
             if isinstance(child, (list, tuple)):
                 # if there are multiple elements, we need to put the `_order` key in each
                 # element
                 for elem in child:
                     if isinstance(elem, dict):
-                        cls._annotate_order_recurse(elem, childorder[k])
+                        cls._annotate_order_recurse(elem, childorder_[k])
 
     @classmethod
     def from_xml(cls, buf, default_prefix='epp', extra_nsmap=None):

--- a/eppy/doc.py
+++ b/eppy/doc.py
@@ -4,7 +4,7 @@ import copy
 from eppy.xmldict import XmlDictObject
 from eppy.xmldict import _BASE_NSMAP
 from past.builtins import unicode, basestring # Python 2 backwards compatibility
-from six import iteritems
+from six import iteritems, PY2, PY3
 from . import childorder
 from .utils import gen_trid
 
@@ -59,8 +59,12 @@ class EppDoc(XmlDictObject):
     def __unicode__(self):
         return self.to_xml(force_prefix=False)
 
-    def __str__(self):
-        return unicode(self).encode('utf-8')
+    if PY2:
+        def __str__(self):
+            return unicode(self).encode('utf-8')
+    elif PY3:
+        def __str__(self):
+            return str(self.__unicode__(), 'utf-8')
 
     # pylint: disable=w0212, e1101
     @classmethod

--- a/eppy/doc.py
+++ b/eppy/doc.py
@@ -1,3 +1,5 @@
+# pylint: disable=C0111
+
 from eppy.xmldict import XmlDictObject
 from eppy.xmldict import _BASE_NSMAP
 import copy
@@ -5,7 +7,6 @@ from past.builtins import unicode, basestring # Python 2 backwards compatibility
 from . import childorder
 from six import iteritems
 from .utils import gen_trid
-
 
 EPP_NSMAP = dict(_BASE_NSMAP)
 EPP_STD_OBJECTS_MAP = {
@@ -42,13 +43,14 @@ class EppDoc(XmlDictObject):
         super(EppDoc, self).__init__(dct, nsmap=nsmap, extra_nsmap=extra_nsmap)
 
     def to_xml(self, force_prefix):
-        # build a dictionary containing the definition of the order that child elements should be serialized
+        # build a dictionary containing the definition of the order that child elements
+        # should be serialized
         # NOTE: this does not contain the root element
         # ``self._childorder`` is defined relative to self._path, so we do some tree grafting here
         qualified_childorder = dpath_make(self._path[1:])
         if self._path[1:]:
             dpath_get(qualified_childorder, self._path[
-                      1:-1])[self._path[-1]] = self._childorder
+                1:-1])[self._path[-1]] = self._childorder
         else:
             qualified_childorder = self._childorder
         return super(EppDoc, self).to_xml(
@@ -60,16 +62,17 @@ class EppDoc(XmlDictObject):
     def __str__(self):
         return unicode(self).encode('utf-8')
 
+    # pylint: disable=w0212
     @classmethod
     def cmddef(cls):
         """
-        Create an `XmlDictObject` based on the `_path` defined, and goes through each super class to wire up
-        the _childorder
+        Create an `XmlDictObject` based on the `_path` defined, and goes through each
+        super class to wire up the _childorder
         """
         dct = dpath_make(cls._path)
 
-        # we need to search mro because if we just did `cls._childorder` it could come from any superclass,
-        # which may not correspond to the same level where `cls._path` is defined.
+        # we need to search mro because if we just did `cls._childorder` it could come from any
+        # superclass, which may not correspond to the same level where `cls._path` is defined.
         # Also, we want to be able to have each level define its own
         # childorder.
         for aclass in cls.__mro__:
@@ -79,21 +82,22 @@ class EppDoc(XmlDictObject):
 
             if '_childorder' in aclass.__dict__:
                 dpath_get(
-                    dct, aclass._path)['_order'] = aclass._childorder.get(
-                    '__order', tuple())
+                    dct, aclass._path)['_order'] = aclass._childorder.get('__order', tuple())
             if '_nsmap' in aclass.__dict__:
                 dpath_get(dct, aclass._path)['_nsmap'] = aclass._nsmap
         return dct
 
+    # pylint: disable=w0212
     @classmethod
     def annotate(cls, dct=None):
         """
-        annotate the given `dct` (or create an empty one) by wiring up the _childorder and _nsmap fields
+        annotate the given `dct` (or create an empty one) by wiring up the _childorder
+        and _nsmap fields
         """
         dct = dct or dpath_make(cls._path)
 
-        # we need to search mro because if we just did `cls._childorder` it could come from any superclass,
-        # which may not correspond to the same level where `cls._path` is defined.
+        # we need to search mro because if we just did `cls._childorder` it could come from any
+        # superclass, which may not correspond to the same level where `cls._path` is defined.
         # Also, we want to be able to have each level define its own
         # childorder.
         for aclass in cls.__mro__:
@@ -125,9 +129,9 @@ class EppDoc(XmlDictObject):
             if isinstance(child, (list, tuple)):
                 # if there are multiple elements, we need to put the `_order` key in each
                 # element
-                for c in child:
-                    if isinstance(c, dict):
-                        cls._annotate_order_recurse(c, childorder[k])
+                for elem in child:
+                    if isinstance(elem, dict):
+                        cls._annotate_order_recurse(elem, childorder[k])
 
     @classmethod
     def from_xml(cls, buf, default_prefix='epp', extra_nsmap=None):
@@ -152,7 +156,7 @@ class EppCommand(EppDoc):
         if hasattr(self, 'namestore_product') and self.namestore_product:
             self['epp']['command'].setdefault(
                 'extension', {})['namestoreExt:namestoreExt'] = {
-                'namestoreExt:subProduct': self.namestore_product}
+                    'namestoreExt:subProduct': self.namestore_product}
             del self.namestore_product
         if hasattr(self, 'phases') and self.phases:
             self.add_command_extension(self.phases)
@@ -162,9 +166,9 @@ class EppCommand(EppDoc):
     def add_command_extension(self, ext_dict):
         self['epp']['command'].setdefault(
             'extension', {}).update(
-            ext_dict.freeze() if isinstance(
-                ext_dict, EppDoc) else ext_dict)
-
+                ext_dict.freeze() if isinstance(
+                    ext_dict, EppDoc) else ext_dict)
+    # pylint: disable=c0103
     def add_clTRID(self, clTRID=None):
         self['epp']['command']['clTRID'] = clTRID or gen_trid()
 
@@ -173,18 +177,20 @@ class EppLoginCommand(EppCommand):
     _path = ('epp', 'command', 'login')
     _childorder = {'__order': childorder.CMD_LOGIN,
                    'svcs': {'__order': ['objURI', 'svcExtension']}}
-
+    # pylint: disable=r0913
+    # pylint: disable=w0613
     def __init__(self, dct=None, nsmap=None, extra_nsmap=None, obj_uris=None,
                  extra_obj_uris=None, extra_ext_uris=None, **kwargs):
         super(
             EppLoginCommand,
             self).__init__(
-            dct=None,
-            nsmap=nsmap,
-            extra_nsmap=extra_nsmap)
+                dct=None,
+                nsmap=nsmap,
+                extra_nsmap=extra_nsmap)
         dpath_get(self, self._path)
         if not hasattr(self, 'options'):
             self.options = {'version': '1.0', 'lang': 'en'}
+        # pylint: disable=w0212
         self.options._order = ['version', 'lang']
 
         if not hasattr(self, 'svcs'):
@@ -356,7 +362,7 @@ class EppUpdateDomainCommand(EppUpdateCommand):
                 record_data = dict(
                     ('secDNS:%s' %
                      k, v) for k, v in iteritems(
-                        item['data']))
+                         item['data']))
                 record_data['_order'] = order
                 update_data.append({record_key: record_data})
             for item in update_data:
@@ -518,6 +524,7 @@ class EppResponse(EppDoc):
         else:
             return '0000'
 
+    # pylint: disable=C0103
     @property
     def ok(self):
         return self.code == '1000'
@@ -534,33 +541,33 @@ class EppResponse(EppDoc):
     def msg(self):
         res = self.first_result
         if res:
-            m = res['msg']
-            if isinstance(m, dict):
-                m = m.get('_text', u'')
+            msg = res['msg']
+            if isinstance(msg, dict):
+                msg = msg.get('_text', u'')
 
             value = res.get('value', [{}])[0]
             if value:
                 if isinstance(value, basestring):
-                    m = u'{}; {}'.format(m, value)
+                    msg = u'{}; {}'.format(msg, value)
                 if isinstance(value, dict):
                     # afilias message looks like
                     # {'{urn:afilias:params:xml:ns:oxrs-1.1}xcp': 'detailed message'}
                     valuemsg = u', '.join(value.values())
                     if valuemsg:
-                        m = u'{}; {}'.format(m, valuemsg)
+                        msg = u'{}; {}'.format(msg, valuemsg)
 
             ext_value = res.get('extValue', [{}])[0]  # take the first one
             reason = ext_value.get(
                 'reason',
                 {}) if isinstance(
-                ext_value,
-                dict) else ''
+                    ext_value,
+                    dict) else ''
             if reason:
                 if isinstance('reason', dict):
                     reason = reason.get('_text', '')
                 if reason:
-                    m = u'{}; {}'.format(m, reason)
-            return m
+                    msg = u'{}; {}'.format(msg, reason)
+            return msg
         else:
             return ''
 
@@ -577,16 +584,16 @@ class EppResponse(EppDoc):
 
 def dpath_get(dct, path, default=None):
     default = {} if default is None else default
-    it = dct
-    for p in path:
-        it = it.get(p, default)
-    return it
+    cur = dct
+    for pat in path:
+        cur = cur.get(pat, default)
+    return cur
 
 
 def dpath_make(path):
     out = {}
-    it = out
-    for p in path:
-        it[p] = {}
-        it = it[p]
+    cur = out
+    for pat in path:
+        cur[pat] = {}
+        cur = cur[pat]
     return out

--- a/eppy/exceptions.py
+++ b/eppy/exceptions.py
@@ -2,6 +2,7 @@ from .doc import EppResponse
 
 
 class EppException(Exception):
+
     def __init__(self, resp):
         if isinstance(resp, EppResponse):
             msg = "{%s} %s" % (resp.code, resp.msg)
@@ -13,6 +14,7 @@ class EppException(Exception):
 
 class EppConnectionError(EppException):
     pass
+
 
 class EppLoginError(EppException):
     pass

--- a/eppy/exceptions.py
+++ b/eppy/exceptions.py
@@ -1,8 +1,11 @@
+"""
+Module that implements EPP exceptions
+"""
 from .doc import EppResponse
 
 
 class EppException(Exception):
-
+    """Base EPP exception"""
     def __init__(self, resp):
         if isinstance(resp, EppResponse):
             msg = "{%s} %s" % (resp.code, resp.msg)
@@ -13,8 +16,10 @@ class EppException(Exception):
 
 
 class EppConnectionError(EppException):
+    """EPP Connection Error. Extends EppException"""
     pass
 
 
 class EppLoginError(EppException):
+    """EPP Loging Error. Extends EppException"""
     pass

--- a/eppy/load_test/__init__.py
+++ b/eppy/load_test/__init__.py
@@ -1,6 +1,1 @@
 from __future__ import absolute_import
-from .behavior import *
-from .context import *
-from .connector import *
-from .session import *
-from .util import *

--- a/eppy/load_test/__init__.py
+++ b/eppy/load_test/__init__.py
@@ -1,1 +1,2 @@
-from __future__ import absolute_import
+#pylint: disable=wildcard-import, W0614
+from __future__ import absolute_import #pylint: disable=wildcard-import, W0614

--- a/eppy/load_test/behavior.py
+++ b/eppy/load_test/behavior.py
@@ -1,20 +1,22 @@
 import random
 import time
 import eppy.doc
+from past.builtins import xrange # Python 2 backwards compatibility
 from .util import randid
 
 
 class Behavior(object):
+
     def __init__(self, ctx, logger=None):
         self.ctx = ctx
         self.logger = logger or self.ctx.getLogger(self)
 
     def __call__(self, client):
-        raise NotImplemented()
-
+        raise NotImplementedError
 
 
 class LoginBehavior(Behavior):
+
     def __init__(self, ctx, userid=None, passwd=None):
         super(LoginBehavior, self).__init__(ctx)
         self.userid = userid or ctx.userid
@@ -28,6 +30,7 @@ class LoginBehavior(Behavior):
 
 
 class LoginNoWaitBehavior(Behavior):
+
     def __init__(self, ctx, userid=None, passwd=None):
         super(LoginNoWaitBehavior, self).__init__(ctx)
         self.userid = userid or ctx.userid
@@ -37,18 +40,20 @@ class LoginNoWaitBehavior(Behavior):
         cmd = eppy.doc.EppLoginCommand()
         cmd.clID = self.userid
         cmd.pw = self.passwd
-        r = client.write(str(cmd))
+        client.write(str(cmd))
         # not reading response!
 
 
 class LoopBehavior(Behavior):
+
     def __init__(self, ctx, behavior, loop=1, sleep=None, sleep_min=0, sleep_max=5):
         super(LoopBehavior, self).__init__(ctx)
         self.behavior = behavior
         self.loop = int(loop)
         if sleep:
             if sleep is None:
-                self.sleep = lambda: time.sleep(sleep_min + random.random()*sleep_max)
+                self.sleep = lambda: time.sleep(
+                    sleep_min + random.random() * sleep_max)
             else:
                 self.sleep = lambda: time.sleep(sleep)
         else:
@@ -57,11 +62,12 @@ class LoopBehavior(Behavior):
     def __call__(self, client):
         for i in xrange(self.loop):
             self.behavior(client)
-            if i < self.loop - 1: # don't sleep at the last one
+            if i < self.loop - 1:  # don't sleep at the last one
                 self.sleep()
 
 
 class BatchSendBehavior(Behavior):
+
     def __init__(self, ctx, cmdgens, pipeline=False):
         super(BatchSendBehavior, self).__init__(ctx)
         self.cmdgens = cmdgens
@@ -77,6 +83,7 @@ class BatchSendBehavior(Behavior):
 
 
 class SingleCommand(Behavior):
+
     def __init__(self, ctx, cmdgen):
         super(SingleCommand, self).__init__(ctx)
         self.cmdgen = cmdgen
@@ -91,18 +98,22 @@ class SingleCommand(Behavior):
 
 
 class NoopBehavior(Behavior):
+
     def __call__(self, client):
         pass
 
 
 class LogoutBehavior(Behavior):
+
     def __call__(self, client):
         r = client.logout()
         return r
 
 
 class BehaviorComposer(Behavior):
-    def __init__(self, ctx, middle_behavior, userid=None, passwd=None, wait_login=True):
+
+    def __init__(self, ctx, middle_behavior, userid=None,
+                 passwd=None, wait_login=True):
         super(BehaviorComposer, self).__init__(ctx)
 
         login_behavior = (LoginBehavior(ctx, userid, passwd)
@@ -114,8 +125,6 @@ class BehaviorComposer(Behavior):
     def __call__(self, client):
         for b in self.behaviors:
             b(client)
-
-
 
 
 def info_domain_factory(zone):
@@ -139,11 +148,12 @@ def strbool(v):
 
 
 BEHAVIORS = {
-    'info_batch': lambda ctx, options, repeat=100: \
-        BatchSendBehavior(ctx, [info_domain_factory(options.zone)]*int(repeat)),
+    'info_batch': lambda ctx, options, repeat=100:
+    BatchSendBehavior(ctx, [info_domain_factory(options.zone)] * int(repeat)),
     'info_loop': lambda ctx, options, loop=20, sleep=1: LoopBehavior(ctx,
-                                                       SingleCommand(ctx, info_domain_factory(options.zone)),
-                                                       loop=loop, sleep=int(sleep)),
+                                                                     SingleCommand(
+                                                                         ctx, info_domain_factory(options.zone)),
+                                                                     loop=loop, sleep=int(sleep)),
     'fatso': lambda ctx, options, num_domains=10: SingleCommand(ctx, check_domain_factory(options.zone, num_domains)),
 }
 
@@ -151,7 +161,6 @@ BEHAVIORS = {
 def parse_behavior(ctx, options):
     behavior_type, _, opts = options.behavior.partition(':')
     opts = opts.split(',') if opts else []
-    behavior = BehaviorComposer(ctx, BEHAVIORS[behavior_type](ctx, options, *opts), wait_login=(not options.no_wait))
+    behavior = BehaviorComposer(ctx, BEHAVIORS[behavior_type](
+        ctx, options, *opts), wait_login=(not options.no_wait))
     return behavior
-
-

--- a/eppy/load_test/connector.py
+++ b/eppy/load_test/connector.py
@@ -2,6 +2,7 @@ from eppy.client import EppClient
 
 
 class Connector(object):
+
     def __init__(self, ctx, behavior, host=None, port=None, ssl_key=None, ssl_cert=None, ssl_cacerts=None,
                  logger=None, read_greeting=True):
         self.ctx = ctx
@@ -14,24 +15,22 @@ class Connector(object):
         self.read_greeting = read_greeting
         self.behavior = behavior
 
-
     def connect(self):
         do_ssl = self.ssl_cert is not None
         client = EppClient(host=self.host, port=self.port,
                            ssl_enable=do_ssl,
-			   ssl_keyfile=self.ssl_key,
-			   ssl_certfile=self.ssl_cert,
-			   ssl_cacerts=self.ssl_cacerts)
+                           ssl_keyfile=self.ssl_key,
+                           ssl_certfile=self.ssl_cert,
+                           ssl_cacerts=self.ssl_cacerts)
         try:
             client.connect(self.host, self.port)
             if self.read_greeting:
-                client.read() # discard greeting
+                client.read()  # discard greeting
         except:
             self.ctx.failed_to_connect()
             raise
         self.ctx.connected()
         return client
-
 
     def __call__(self):
         try:
@@ -42,5 +41,3 @@ class Connector(object):
 
     def __str__(self):
         return self.__class__.__name__
-
-

--- a/eppy/load_test/context.py
+++ b/eppy/load_test/context.py
@@ -1,7 +1,10 @@
 import logging
 
+
 class ExecutionContext(object):
-    def __init__(self, host=None, port=None, ssl_key=None, ssl_cert=None, ssl_cacerts=None, userid=None, passwd=None):
+
+    def __init__(self, host=None, port=None, ssl_key=None, ssl_cert=None,
+                 ssl_cacerts=None, userid=None, passwd=None):
         self.host = host
         self.port = port
         self.ssl_key = ssl_key
@@ -10,10 +13,10 @@ class ExecutionContext(object):
         self.userid = userid
         self.passwd = passwd
         self.max_ident = 0
-        self.total_connected = 0 # ever connected
+        self.total_connected = 0  # ever connected
         self.num_connected = 0
         self.num_authenticated = 0
-        self.failed_connections = 0 # ever connected
+        self.failed_connections = 0  # ever connected
         self.num_commands_sent = 0
         self.num_responses_recved = 0
 
@@ -50,4 +53,3 @@ class ExecutionContext(object):
         print "%5d Authenticated" % self.num_authenticated
         print "%5d Commands sent" % self.num_commands_sent
         print "%5d Responses received" % self.num_responses_recved
-

--- a/eppy/load_test/main.py
+++ b/eppy/load_test/main.py
@@ -1,8 +1,10 @@
-from gevent import monkey
-monkey.patch_all()
+# pylint: disable=W0614, w0401, w0611, e0401
 from eppy.load_test import *
-import sys
 from optparse import OptionParser
+from gevent import monkey # pylint: disable=W0614, w0401, w0611, e0401
+monkey.patch_all()
+import sys
+import logging
 
 
 def main():

--- a/eppy/load_test/main.py
+++ b/eppy/load_test/main.py
@@ -1,20 +1,29 @@
-from gevent import monkey; monkey.patch_all()
-import gevent
-import gevent.pool
+from gevent import monkey
+monkey.patch_all()
 from eppy.load_test import *
 import sys
 from optparse import OptionParser
 
 
-
 def main():
     parser = OptionParser(usage="%prog <userid> <passwd>")
-    parser.add_option('-c', type=int, dest='concurrency', default=1, help='number of concurrent connections')
-    parser.add_option('-n', type=int, dest='num_connectors', default=1, help='number of connections to make')
+    parser.add_option('-c', type=int, dest='concurrency', default=1,
+                      help='number of concurrent connections')
+    parser.add_option(
+        '-n',
+        type=int,
+        dest='num_connectors',
+        default=1,
+        help='number of connections to make')
     parser.add_option('--behavior', default='info_loop')
     parser.add_option('--no-wait', action='store_true', default=True)
     parser.add_option('--host', default='localhost', help='EPP host to connect to')
-    parser.add_option('--port', '-p', default=700, type=int, help='EPP port to connect to')
+    parser.add_option(
+        '--port',
+        '-p',
+        default=700,
+        type=int,
+        help='EPP port to connect to')
     parser.add_option('--ssl-key', default='certs/client-key.pem')
     parser.add_option('--ssl-cert', default='certs/client-cert.pem')
     parser.add_option('--ssl-cacerts', default='certs/cacerts.pem')
@@ -27,8 +36,7 @@ def main():
         sys.exit(1)
 
     logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
-    logger = logging.getLogger()
-
+    logging.getLogger()
 
     ctx = ExecutionContext(host=options.host,
                            port=options.port,
@@ -37,7 +45,6 @@ def main():
                            ssl_cacerts=options.ssl_cacerts,
                            userid=args[0],
                            passwd=args[1])
-
 
     behavior = parse_behavior(ctx, options)
     session = Session(ctx, behavior)
@@ -52,11 +59,9 @@ def main():
 if __name__ == '__main__':
     main()
 
-#chaos
-#swarm
+# chaos
+# swarm
 #swamp, flood
-#bezerk
-#ballistic
-#session has a connector, looper, bezerk modifier, 
-
-
+# bezerk
+# ballistic
+# session has a connector, looper, bezerk modifier,

--- a/eppy/load_test/session.py
+++ b/eppy/load_test/session.py
@@ -1,5 +1,6 @@
 import gevent.pool
 import time
+from past.builtins import xrange # Python 2 backwards compatibility
 from .connector import Connector
 
 

--- a/eppy/load_test/session.py
+++ b/eppy/load_test/session.py
@@ -4,6 +4,7 @@ from .connector import Connector
 
 
 class Session(object):
+
     def __init__(self, ctx, behavior=None):
         self.num_connectors = 1
         self.concurrency = 1
@@ -22,5 +23,3 @@ class Session(object):
             pool.join()
         except KeyboardInterrupt:
             pass
-
-

--- a/eppy/load_test/util.py
+++ b/eppy/load_test/util.py
@@ -5,6 +5,8 @@ import random
 
 
 CSET = string.lowercase + string.digits + string.uppercase
+
+
 def randid(min=5, max=15):
     """
     Generate a random ID which size is at least <min> and
@@ -14,4 +16,3 @@ def randid(min=5, max=15):
         max = min + 1
     return ''.join([random.choice(CSET) for i in range(min +
                                                        random.choice(range(max - min)))])
-

--- a/eppy/load_test/util.py
+++ b/eppy/load_test/util.py
@@ -3,16 +3,14 @@
 import string
 import random
 
+CSET = string.ascii_letters + string.digits
 
-CSET = string.lowercase + string.digits + string.uppercase
-
-
-def randid(min=5, max=15):
+def randid(mini=5, maxi=15):
     """
-    Generate a random ID which size is at least <min> and
-    at most <max> characters
+    Generate a random ID which size is at least <mini> and
+    at most <maxi> characters
     """
-    if max <= min:
-        max = min + 1
-    return ''.join([random.choice(CSET) for i in range(min +
-                                                       random.choice(range(max - min)))])
+    if maxi <= mini:
+        maxi = mini + 1
+    return ''.join([random.choice(CSET) for i in range(mini +
+                                                       random.choice(range(maxi - mini)))])

--- a/eppy/utils.py
+++ b/eppy/utils.py
@@ -3,5 +3,6 @@ from random import choice
 
 TRID_CSET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
+
 def gen_trid(length=12):
     return ''.join(choice(TRID_CSET) for _i in range(length))

--- a/eppy/xmldict.py
+++ b/eppy/xmldict.py
@@ -78,18 +78,18 @@ class XmlDictObject(dict):
         self.__initialized = True
 
     def __getattr__(self, item):
-        it = self
-        for p in self._path:
-            it = it[p]
-        if item in it:
-            return it[item]
+        items = self
+        for path in self._path:
+            items = items[path]
+        if item in items:
+            return items[item]
         else:
             # we are calling the `dict` version of __str__ in case the regular __str__ implementation got overridden
             # by a subclass that somehow calls this method again causing an
             # unterminated recursion
             raise AttributeError("no such node (%s/%s) in: %r (self=%s)" % ('/'.join(self._path),
                                                                             item,
-                                                                            it,
+                                                                            items,
                                                                             dict.__str__(self)))
 
     def __setattr__(self, item, value):
@@ -101,23 +101,23 @@ class XmlDictObject(dict):
             super(XmlDictObject, self).__setattr__(item, value)
             return
 
-        it = self
-        for p in self._path:
-            it = it.__getitem__(p)
+        items = self
+        for path in self._path:
+            items = items.__getitem__(path)
 
         if isinstance(value, dict):
             value = XmlDictObject(value)
-        return it.__setitem__(item, value)
+        return items.__setitem__(item, value)
 
     def __delattr__(self, item):
         if item.startswith("__"):
             super(XmlDictObject, self).__delattr__(item)
             return
 
-        it = self
-        for p in self._path:
-            it = it.__getitem__(p)
-        return it.__delitem__(item)
+        items = self
+        for path in self._path:
+            items = items.__getitem__(path)
+        return items.__delitem__(item)
 
     def __str__(self):
         if '_text' in self:

--- a/eppy/xmldict.py
+++ b/eppy/xmldict.py
@@ -9,7 +9,7 @@ functions to convert an XML file into a python dict, back and forth
 #         modified to handle attributes, namespaces..
 
 __author__ = "Wil Tan <wil@cloudregistry.net>"
-
+from xml.etree import ElementTree
 from six import StringIO, iteritems, text_type
 
 # hack: LCGCMT had the py-2.5 xml.etree module hidden by mistake.
@@ -35,7 +35,7 @@ def import_etree():
     return etree
 
 etree = import_etree()
-from xml.etree import ElementTree
+
 
 # module data ----------------------------------------------------------------
 __all__ = [
@@ -52,7 +52,8 @@ _BASE_NSMAP = {
 
 class XmlDictObject(dict):
     _path = ()
-    _childorder = {}  # relative to _path; only useful if defined at the same level at which _path is defined/overridden
+    _childorder = {}  # relative to _path; only useful if defined at the same
+                      # level at which _path is defined/overridden
     _multi_nodes = set()
 
     def __init__(self, initdict=None, nsmap=None, extra_nsmap=None):
@@ -70,8 +71,8 @@ class XmlDictObject(dict):
         nsmap_r = {}
         # build reverse map
         for prefix, uri in iteritems(nsmap):
-            if uri in nsmap_r and not prefix:  # default prefix should not override anything already in the rmap
-                continue
+            if uri in nsmap_r and not prefix:  # default prefix should not override anything
+                continue                # already in the rmap override anything already in the rmap
             nsmap_r[uri] = prefix
         self._nsmap_r = nsmap_r
 
@@ -84,9 +85,9 @@ class XmlDictObject(dict):
         if item in items:
             return items[item]
         else:
-            # we are calling the `dict` version of __str__ in case the regular __str__ implementation got overridden
-            # by a subclass that somehow calls this method again causing an
-            # unterminated recursion
+            # we are calling the `dict` version of __str__ in case the regular
+            # __str__ implementation got overridden
+            # by a subclass that somehow calls this method again causing an unterminated recursion
             raise AttributeError("no such node (%s/%s) in: %r (self=%s)" % ('/'.join(self._path),
                                                                             item,
                                                                             items,

--- a/eppy/xmldict.py
+++ b/eppy/xmldict.py
@@ -1,3 +1,6 @@
+"""\
+functions to convert an XML file into a python dict, back and forth
+"""
 # @purpose converts an XML file into a python dict, back and forth
 # @author http://code.activestate.com/recipes/573463
 #         slightly adapted to follow PEP8 conventions
@@ -5,15 +8,14 @@
 # @author "Sebastien Binet <binet@cern.ch>"
 #         modified to handle attributes, namespaces..
 
-__doc__ = """\
-functions to convert an XML file into a python dict, back and forth
-"""
 __author__ = "Wil Tan <wil@cloudregistry.net>"
 
 from six import StringIO, iteritems, text_type
 
 # hack: LCGCMT had the py-2.5 xml.etree module hidden by mistake.
 #       this is to import it, by hook or by crook
+
+
 def import_etree():
     import xml
     # first try the usual way
@@ -23,7 +25,8 @@ def import_etree():
     except ImportError:
         pass
     # do it by hook or by crook...
-    import sys, os, imp
+    import os
+    import imp
     xml_site_package = os.path.join(os.path.dirname(os.__file__), 'xml')
     m = imp.find_module('etree', [xml_site_package])
 
@@ -34,24 +37,27 @@ def import_etree():
 etree = import_etree()
 from xml.etree import ElementTree
 
-## module data ----------------------------------------------------------------
+# module data ----------------------------------------------------------------
 __all__ = [
     'xml2dict',
     'dict2xml',
-    ]
+]
 
 _BASE_NSMAP = {
     'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
 }
 
-## module implementation ------------------------------------------------------
+# module implementation ------------------------------------------------------
+
+
 class XmlDictObject(dict):
     _path = ()
-    _childorder = {} # relative to _path; only useful if defined at the same level at which _path is defined/overridden
+    _childorder = {}  # relative to _path; only useful if defined at the same level at which _path is defined/overridden
     _multi_nodes = set()
 
     def __init__(self, initdict=None, nsmap=None, extra_nsmap=None):
-        # NOTE: setting attributes in __init__ will require special handling, see XmlDictObject
+        # NOTE: setting attributes in __init__ will require special handling, see
+        # XmlDictObject
         if initdict is None:
             initdict = {}
         dict.__init__(self, initdict)
@@ -64,13 +70,12 @@ class XmlDictObject(dict):
         nsmap_r = {}
         # build reverse map
         for prefix, uri in iteritems(nsmap):
-            if uri in nsmap_r and not prefix: # default prefix should not override anything already in the rmap
+            if uri in nsmap_r and not prefix:  # default prefix should not override anything already in the rmap
                 continue
             nsmap_r[uri] = prefix
         self._nsmap_r = nsmap_r
 
         self.__initialized = True
-
 
     def __getattr__(self, item):
         it = self
@@ -80,12 +85,12 @@ class XmlDictObject(dict):
             return it[item]
         else:
             # we are calling the `dict` version of __str__ in case the regular __str__ implementation got overridden
-            # by a subclass that somehow calls this method again causing an unterminated recursion
+            # by a subclass that somehow calls this method again causing an
+            # unterminated recursion
             raise AttributeError("no such node (%s/%s) in: %r (self=%s)" % ('/'.join(self._path),
                                                                             item,
                                                                             it,
                                                                             dict.__str__(self)))
-
 
     def __setattr__(self, item, value):
         if '_XmlDictObject__initialized' not in self.__dict__:
@@ -100,10 +105,9 @@ class XmlDictObject(dict):
         for p in self._path:
             it = it.__getitem__(p)
 
-        if type(value) is dict:
+        if isinstance(value, dict):
             value = XmlDictObject(value)
         return it.__setitem__(item, value)
-
 
     def __delattr__(self, item):
         if item.startswith("__"):
@@ -115,7 +119,6 @@ class XmlDictObject(dict):
             it = it.__getitem__(p)
         return it.__delitem__(item)
 
-
     def __str__(self):
         if '_text' in self:
             return self['_text']
@@ -125,8 +128,8 @@ class XmlDictObject(dict):
     @staticmethod
     def wrap(x):
         if isinstance(x, dict):
-            return XmlDictObject ((k, XmlDictObject.wrap(v))
-                                  for (k, v) in iteritems(x))
+            return XmlDictObject((k, XmlDictObject.wrap(v))
+                                 for (k, v) in iteritems(x))
         elif isinstance(x, list):
             return [XmlDictObject.wrap(v) for v in x]
         else:
@@ -135,32 +138,35 @@ class XmlDictObject(dict):
     @staticmethod
     def _unwrap(x):
         if isinstance(x, dict):
-            return dict ((k, XmlDictObject._unwrap(v))
-                         for (k, v) in iteritems(x))
+            return dict((k, XmlDictObject._unwrap(v))
+                        for (k, v) in iteritems(x))
         elif isinstance(x, list):
             return [XmlDictObject._unwrap(v) for v in x]
         else:
             return x
-
 
     def to_xml(self, childorder, force_prefix=False):
         el = dict2xml(self, childorder, force_prefix=force_prefix)
         indent(el)
         return ElementTree.tostring(el)
 
-
     @classmethod
     def from_xml(cls, buf, default_prefix=None, extra_nsmap=None):
         root = ElementTree.parse(StringIO(buf)).getroot()
-        rv = xml2dict(root, outerclass=cls, default_prefix=default_prefix, multi_nodes=cls._multi_nodes, extra_nsmap=extra_nsmap)
+        rv = xml2dict(
+            root,
+            outerclass=cls,
+            default_prefix=default_prefix,
+            multi_nodes=cls._multi_nodes,
+            extra_nsmap=extra_nsmap)
         return rv
 
-        
     def unwrap(self):
         return XmlDictObject._unwrap(self)
 
 
-def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes, childorder, force_prefix=False):
+def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes,
+                      childorder, force_prefix=False):
     """
     :param nsmap: is a dict, can be `{}`
     :param current_prefixes: is a set
@@ -168,8 +174,9 @@ def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes, childorder, for
     """
     if '_order' in dictitem or '__order' in childorder:
         ordr = dictitem.get('_order') or childorder.get('__order', [])
-        nodeorder = dict((name, i) for i,name in enumerate(ordr))
-        items = sorted(iteritems(dictitem), key=lambda x: nodeorder.get(x[0].split(":")[-1], 0))
+        nodeorder = dict((name, i) for i, name in enumerate(ordr))
+        items = sorted(iteritems(dictitem),
+                       key=lambda x: nodeorder.get(x[0].split(":")[-1], 0))
     else:
         items = iteritems(dictitem)
 
@@ -185,7 +192,12 @@ def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes, childorder, for
             parent.text = text_type(child)
         elif tag.startswith("@"):
             attrname = tag[1:]
-            _do_xmlns(parent, attrname, current_prefixes, nsmap, set_default_ns=False)
+            _do_xmlns(
+                parent,
+                attrname,
+                current_prefixes,
+                nsmap,
+                set_default_ns=False)
             parent.set(attrname, text_type(child))
         elif type(child) in (list, tuple):
             for listchild in child:
@@ -193,9 +205,11 @@ def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes, childorder, for
                 prefixes_recurs = current_prefixes.copy()
                 if ":" in tag:
                     elem = ElementTree.Element(tag)
-                    prefix, uri = _do_xmlns(elem, tag, current_prefixes, nsmap, set_default_ns=not force_prefix)
-                    if uri: # we will change the default namespace for children with no prefix
-                        # so we need to make copies of nsmap and current_prefixes instead of updating in-place
+                    prefix, uri = _do_xmlns(
+                        elem, tag, current_prefixes, nsmap, set_default_ns=not force_prefix)
+                    if uri:  # we will change the default namespace for children with no prefix
+                        # so we need to make copies of nsmap and current_prefixes instead
+                        # of updating in-place
                         nsmap_recurs = nsmap.copy()
                         if not force_prefix:
                             nsmap_recurs[''] = uri
@@ -211,7 +225,8 @@ def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes, childorder, for
                 parent.append(elem)
                 if isinstance(listchild, dict):
                     tag_prefix = tag.partition(':')[0] if ':' in tag else ''
-                    reltag = tag.rpartition(':')[2] if not tag_prefix or tag_prefix == parent_prefix else tag
+                    reltag = tag.rpartition(
+                        ':')[2] if not tag_prefix or tag_prefix == parent_prefix else tag
                     _dict2xml_recurse(elem,
                                       listchild,
                                       nsmap=nsmap_recurs,
@@ -227,8 +242,9 @@ def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes, childorder, for
                 elem = ElementTree.Element(tag)
                 if isinstance(child, dict) and '_nsmap' in child:
                     nsmap_recurs.update(child['_nsmap'])
-                prefix, uri = _do_xmlns(elem, tag, current_prefixes, nsmap_recurs, set_default_ns=not force_prefix)
-                if uri: # we will change the default namespace for children with no prefix
+                prefix, uri = _do_xmlns(
+                    elem, tag, current_prefixes, nsmap_recurs, set_default_ns=not force_prefix)
+                if uri:  # we will change the default namespace for children with no prefix
                     if not force_prefix:
                         nsmap_recurs[''] = uri
                     prefixes_recurs = current_prefixes.union([prefix])
@@ -243,7 +259,8 @@ def _dict2xml_recurse(parent, dictitem, nsmap, current_prefixes, childorder, for
             parent.append(elem)
             if isinstance(child, dict):
                 tag_prefix = tag.partition(':')[0] if ':' in tag else ''
-                reltag = tag.rpartition(':')[2] if not tag_prefix or tag_prefix == parent_prefix else tag
+                reltag = tag.rpartition(
+                    ':')[2] if not tag_prefix or tag_prefix == parent_prefix else tag
                 _dict2xml_recurse(elem,
                                   child,
                                   nsmap=nsmap_recurs,
@@ -300,8 +317,8 @@ def _compute_prefix(tag, nsmap_r={}, default_prefix=None):
         enduri = tag.index("}")
         prefix = nsmap_r.get(tag[1:enduri])
         if prefix is not None:
-            tag = tag[enduri+1:]
-            if prefix != default_prefix: # namespace changed
+            tag = tag[enduri + 1:]
+            if prefix != default_prefix:  # namespace changed
                 tag = "%s:%s" % (prefix, tag)
                 default_prefix = prefix
     return tag, default_prefix
@@ -311,7 +328,7 @@ def get_prefix_and_name(nsmap_r, name):
     if name.startswith('{'):
         enduri = name.index("}")
         prefix = nsmap_r.get(name[1:enduri])
-        return prefix, name[enduri+1:]
+        return prefix, name[enduri + 1:]
     else:
         return None, name
 
@@ -325,27 +342,29 @@ def get_prefixed_name(nsmap_r, name):
         return name
 
 
-def _xml2dict_recurse(node, nodedict, dictclass, nsmap, nsmap_r, default_prefix=None, parent_path=None, multi_nodes=None):
+def _xml2dict_recurse(node, nodedict, dictclass, nsmap, nsmap_r,
+                      default_prefix=None, parent_path=None, multi_nodes=None):
     parent_path = parent_path or tuple()
     if len(node.items()) > 0:
         # if we have attributes, set them
-        ## wil/rem nodedict.update(dict(node.items()))
-        nodedict.update(dict(("@%s" % get_prefixed_name(nsmap_r, k), v) for k,v in node.items()))
+        # wil/rem nodedict.update(dict(node.items()))
+        nodedict.update(dict(("@%s" % get_prefixed_name(nsmap_r, k), v)
+                             for k, v in node.items()))
 
     for child in node:
         childtag, childprefix = _compute_prefix(child.tag, nsmap_r, default_prefix)
 
-        #print "recursing with", childtag, "[", childprefix, "] default=", default_prefix
+        # print "recursing with", childtag, "[", childprefix, "] default=", default_prefix
         # recursively add the element's children
         newitem = _xml2dict_recurse(child, dictclass(), dictclass, nsmap, nsmap_r,
                                     default_prefix=childprefix,
                                     multi_nodes=multi_nodes,
-                                    parent_path=parent_path+(childtag,))
+                                    parent_path=parent_path + (childtag,))
 
         nodeval = nodedict.get(childtag)
         if nodeval is not None:
             # found duplicate tag, force a list
-            if type(nodeval) is list:
+            if isinstance(nodeval, list):
                 # append to existing list
                 nodeval.append(newitem)
             else:
@@ -355,7 +374,8 @@ def _xml2dict_recurse(node, nodedict, dictclass, nsmap, nsmap_r, default_prefix=
             nodedict.setdefault('_order', []).append(childtag)
             nodepath = parent_path + (childtag,)
             if multi_nodes and nodepath in multi_nodes:
-                # if this node is configured to appear multiple times, put it in a list
+                # if this node is configured to appear multiple times, put it in a
+                # list
                 nodedict[childtag] = [newitem]
             else:
                 # only one, directly set the dictionary
@@ -375,11 +395,12 @@ def _xml2dict_recurse(node, nodedict, dictclass, nsmap, nsmap_r, default_prefix=
         # if we don't have child nodes or attributes, just set the text
         nodedict = node.text.strip() if node.text else ""
 
-    #print "end nodedict = %r" % (nodedict,)
+    # print "end nodedict = %r" % (nodedict,)
     return nodedict
 
 
-def xml2dict(root, dictclass=XmlDictObject, outerclass=XmlDictObject, default_prefix=None, multi_nodes=None, extra_nsmap=None):
+def xml2dict(root, dictclass=XmlDictObject, outerclass=XmlDictObject,
+             default_prefix=None, multi_nodes=None, extra_nsmap=None):
     """convert an xml tree into a python dictionary
     """
     rootnode = dictclass()
@@ -397,17 +418,16 @@ def xml2dict(root, dictclass=XmlDictObject, outerclass=XmlDictObject, default_pr
 
 
 def indent(elem, level=0):
-    i = "\n" + level*"  "
+    i = "\n" + level * "  "
     if len(elem):
         if not elem.text or not elem.text.strip():
             elem.text = i + "  "
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
         for elem in elem:
-            indent(elem, level+1)
+            indent(elem, level + 1)
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
     else:
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
-

--- a/eppy/xmldict.py
+++ b/eppy/xmldict.py
@@ -10,7 +10,7 @@ functions to convert an XML file into a python dict, back and forth
 
 __author__ = "Wil Tan <wil@cloudregistry.net>"
 from xml.etree import ElementTree
-from six import StringIO, iteritems, text_type
+from six import StringIO, iteritems, text_type, PY2, PY3
 
 # hack: LCGCMT had the py-2.5 xml.etree module hidden by mistake.
 #       this is to import it, by hook or by crook
@@ -153,7 +153,11 @@ class XmlDictObject(dict):
 
     @classmethod
     def from_xml(cls, buf, default_prefix=None, extra_nsmap=None):
-        root = ElementTree.parse(StringIO(buf)).getroot()
+        if PY2:
+            root = ElementTree.parse(StringIO(buf)).getroot()
+        else: 
+            root = ElementTree.fromstring(buf)
+        
         rv = xml2dict(
             root,
             outerclass=cls,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 from eppy import __version__
 
-install_requires = ['six']
+install_requires = ['six', 'future']
 if sys.version_info < (3,2):
     install_requires.append('backports.ssl_match_hostname')
 


### PR DESCRIPTION
Hi! We use this library in house @ CIRA, had to update this to work on one of our projects that uses py3. I tried to make most of these changes backwards compatible to Python 2. Also linted mostly everything to follow PEP conventions. I did not update every single thing in there, but everything that we use works. Figured that should help you with the update to python 3.

My changes require six and future (for backwards compat to py2) to work.

Cheers