### PR TITLE
connect: accept other address families, make host optional

### DIFF
--- a/eppy/client.py
+++ b/eppy/client.py
@@ -63,13 +63,13 @@ class EppClient(object):
         else:
             self.cert_required = ssl.CERT_NONE
 
-    def connect(self, host, port=None):
+    def connect(self, host=None, port=None, address_family=None):
         """
         Method that initiates a connection to an EPP host
         """
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock = socket.socket(address_family or socket.AF_INET, socket.SOCK_STREAM)
         self.sock.settimeout(self.socket_connect_timeout)  # connect timeout
-        self.sock.connect((host, port or self.port))
+        self.sock.connect((host or self.host, port or self.port))
         local_sock_addr = self.sock.getsockname()
         local_addr, local_port = local_sock_addr[:2]
         self.log.debug('connected local=%s:%s remote=%s:%s',

--- a/eppy/client.py
+++ b/eppy/client.py
@@ -67,9 +67,10 @@ class EppClient(object):
         """
         Method that initiates a connection to an EPP host
         """
+        host = host or self.host
         self.sock = socket.socket(address_family or socket.AF_INET, socket.SOCK_STREAM)
         self.sock.settimeout(self.socket_connect_timeout)  # connect timeout
-        self.sock.connect((host or self.host, port or self.port))
+        self.sock.connect((host, port or self.port))
         local_sock_addr = self.sock.getsockname()
         local_addr, local_port = local_sock_addr[:2]
         self.log.debug('connected local=%s:%s remote=%s:%s',


### PR DESCRIPTION
this PR changes the connect method to add an address_family argument, which allows us to connect over IPv6 (using `address_family=socket.AF_INET6` ). Also it makes the host argument optional, as we already can use the hostname set on the `EppClient` object, making it consistent with the port argument.