### PR TITLE
add changePoll as well known name space

### DIFF
--- a/eppy/doc.py
+++ b/eppy/doc.py
@@ -28,8 +28,8 @@ EPP_NSMAP.update({
     'launch': 'urn:ietf:params:xml:ns:launch-1.0',
     'smd': 'urn:ietf:params:xml:ns:signedMark-1.0',
     'mark': 'urn:ietf:params:xml:ns:mark-1.0',
+    'changePoll': 'urn:ietf:params:xml:ns:changePoll-1.0',
 })
-
 
 class EppDoc(XmlDictObject):
 


### PR DESCRIPTION
This PR simply adds the changePoll extension to the NSMAP

Change Poll ( https://tools.ietf.org/html/draft-ietf-regext-change-poll-08 ) is currently still draft but likely to become an RFC soon. It is already in use by SWITCH (the registry for .ch and .li ) for the upcoming support of automated DS record changes ( RFC7344 / RFC8078 )
